### PR TITLE
override region from ::Aws.config[:region]

### DIFF
--- a/lib/vagrant-s3auth-mfa/util.rb
+++ b/lib/vagrant-s3auth-mfa/util.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
         unless ENV['AWS_CONFIG_PROFILE'].nil?
           config = AWSConfig[ENV['AWS_CONFIG_PROFILE']]
           set_credentials_from_profile(config) if ::Aws.config.empty?
+          region = ::Aws.config[:region]
         end
         ::Aws::S3::Client.new(region: region)
       end


### PR DESCRIPTION
Hello Maintainers,

I just made a small change to the plugin.

* Use case: 

vagrant box add from cross account s3 bucket located in other than DEFAULT_REGION("us-east-1") using AWS_CONFIG_PROFILE environment variable.

* Test result:

```bash
$ AWS_CONFIG_PROFILE=`profile name` bundle exec vagrant box add --force `box name` s3://`bucket name`/package.box
You appear to be running Vagrant outside of the official installers.
Note that the installers are what ensure that Vagrant has all required
dependencies, and Vagrant assumes that these dependencies exist. By
running outside of the installer environment, Vagrant may not function
properly. To remove this warning, install Vagrant using one of the
official packages from vagrantup.com.

==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box '`box name`' (v0) for provider:
    box: Downloading: s3://`bucket name`/package.box
==> box: Box download is resuming from prior download progress
    box: Signing S3 request with profile '`profile name`' loaded from ~/.aws/config
==> box: Successfully added box '`box name`' (v0) for 'virtualbox'!
```

* issue ref:

https://github.com/WhoopInc/vagrant-s3auth/issues/38

Hope this message finds you well.

Regards,
Shintaro Maruyama
